### PR TITLE
Added --image-ctf-premultiplied & --image-dose-weighted args to train_vae

### DIFF
--- a/tomodrgn/commands/backproject_voxel.py
+++ b/tomodrgn/commands/backproject_voxel.py
@@ -78,7 +78,7 @@ def backproject_dataset(data: TiltSeriesMRCData | TomoParticlesMRCData,
     batchsize = 1
     data_generator = torch.utils.data.DataLoader(data, batch_size=batchsize, shuffle=False)
 
-    for batch_images, batch_rot, batch_trans, batch_ctf_params, batch_frequency_weights, _, batch_indices in data_generator:
+    for batch_images, batch_rot, batch_trans, batch_ctf_params, batch_frequency_weights, _, batch_indices, _ in data_generator:
 
         # logging
         n_ptcls_backprojected += len(batch_indices)

--- a/tomodrgn/commands/train_nn.py
+++ b/tomodrgn/commands/train_nn.py
@@ -153,6 +153,7 @@ def train_batch(model: FTPositionalDecoder | DataParallelPassthrough,
                 batch_trans: torch.Tensor,
                 batch_ctf_params: torch.Tensor,
                 batch_recon_error_weights: torch.Tensor,
+                batch_dose_weights: torch.Tensor,
                 batch_hartley_2d_mask: torch.Tensor,
                 image_ctf_premultiplied: bool,
                 image_dose_weighted: bool,
@@ -173,6 +174,7 @@ def train_batch(model: FTPositionalDecoder | DataParallelPassthrough,
     :param batch_recon_error_weights: Batch of 2-D weights to be applied to the per-spatial-frequency error between the reconstructed slice and the input image.
             Calculated from critical dose exposure curves and electron beam vs sample tilt geometry.
             May be `torch.zeros((batchsize))` instead to indicate no weighting should be applied to the reconstructed slice error.
+    :param batch_dose_weights: Dose-only frequency weights per tilt image, shape (batchsize, ntilts, boxsize_ht**2).
     :param batch_hartley_2d_mask: Batch of 2-D masks to be applied per-spatial-frequency.
             Calculated as the intersection of critical dose exposure curves and a Nyquist-limited circular mask in reciprocal space, including masking the DC component.
     :param image_ctf_premultiplied: Whether images were multiplied by their CTF during particle extraction.
@@ -202,6 +204,7 @@ def train_batch(model: FTPositionalDecoder | DataParallelPassthrough,
                                  batch_images_recon=batch_images_recon,
                                  batch_ctf_weights=batch_ctf_weights,
                                  batch_recon_error_weights=batch_recon_error_weights,
+                                 batch_dose_weights=batch_dose_weights,
                                  batch_hartley_2d_mask=batch_hartley_2d_mask,
                                  image_ctf_premultiplied=image_ctf_premultiplied,
                                  image_dose_weighted=image_dose_weighted)
@@ -248,6 +251,7 @@ def loss_function(*,
                   batch_images_recon: torch.Tensor,
                   batch_ctf_weights: torch.Tensor,
                   batch_recon_error_weights: torch.Tensor,
+                  batch_dose_weights: torch.Tensor,
                   batch_hartley_2d_mask: torch.Tensor,
                   image_ctf_premultiplied: bool,
                   image_dose_weighted: bool) -> torch.Tensor:
@@ -276,6 +280,7 @@ def loss_function(*,
         # reconstruction error
         batch_images = batch_images[batch_hartley_2d_mask].view(-1)
         batch_recon_error_weights = batch_recon_error_weights[batch_hartley_2d_mask].view(-1)
+        batch_dose_weights = batch_dose_weights[batch_hartley_2d_mask].view(-1)
         if batch_ctf_weights is not None:
             batch_ctf_weights = batch_ctf_weights[batch_hartley_2d_mask].view(-1)
             batch_images_recon = batch_images_recon * batch_ctf_weights  # apply CTF to reconstructed image
@@ -286,8 +291,9 @@ def loss_function(*,
                 # reconstructed image needs to correspond to input ctf_premultiplied images, i.e. images that are doubly convolved with the CTF
                 batch_images_recon = batch_images_recon * batch_ctf_weights  # apply CTF to reconstructed image again
         if image_dose_weighted:
-            # images may have been extracted with dose weights pre-applied
-            batch_images_recon = batch_images_recon * batch_recon_error_weights
+            # divide dose weights out of input images so both sides compare on equal footing;
+            # clamp avoids division by zero at masked frequencies (l_dose_mask handles zero-weight regions)
+            batch_images = batch_images / batch_dose_weights.clamp(min=1e-6)
         gen_loss = torch.mean(batch_recon_error_weights * ((batch_images_recon - batch_images) ** 2))
 
     return gen_loss
@@ -450,7 +456,7 @@ def main(args):
         t2 = dt.now()
         loss_accum = 0
         batch_it = 0
-        for batch_images, batch_rots, batch_trans, batch_ctf_params, batch_recon_error_weights, batch_hartley_2d_mask, batch_indices in data_generator:
+        for batch_images, batch_rots, batch_trans, batch_ctf_params, batch_recon_error_weights, batch_hartley_2d_mask, batch_indices, batch_dose_weights in data_generator:
             # impression counting
             batch_it += len(batch_images)
 
@@ -460,6 +466,7 @@ def main(args):
             batch_trans = batch_trans.to(device)
             batch_ctf_params = batch_ctf_params.to(device)
             batch_recon_error_weights = batch_recon_error_weights.to(device)
+            batch_dose_weights = batch_dose_weights.to(device)
             batch_hartley_2d_mask = batch_hartley_2d_mask.to(device)
 
             # training minibatch
@@ -472,6 +479,7 @@ def main(args):
                                      batch_trans=batch_trans,
                                      batch_ctf_params=batch_ctf_params,
                                      batch_recon_error_weights=batch_recon_error_weights,
+                                     batch_dose_weights=batch_dose_weights,
                                      batch_hartley_2d_mask=batch_hartley_2d_mask,
                                      image_ctf_premultiplied=image_ctf_premultiplied,
                                      image_dose_weighted=image_dose_weighted,

--- a/tomodrgn/commands/train_vae.py
+++ b/tomodrgn/commands/train_vae.py
@@ -49,6 +49,14 @@ def add_args(parser: argparse.ArgumentParser | None = None) -> argparse.Argument
     group = parser.add_argument_group('Particle starfile loading and filtering')
     group.add_argument('--source-software', type=str, choices=get_args(KNOWN_STAR_SOURCES), default='auto',
                        help='Manually set the software used to extract particles. Default is to auto-detect.')
+    group.add_argument('--image-ctf-premultiplied', type=lambda x: x.lower() == 'true',
+                       default=None, metavar='BOOL',
+                       help='Override whether CTF premultiplication was applied during extraction (true/false). '
+                       'Default: auto-detected from star file.')
+    group.add_argument('--image-dose-weighted', type=lambda x: x.lower() == 'true',
+                       default=None, metavar='BOOL',
+                       help='Override whether dose weighting was applied during extraction (true/false). '
+                       'Default: auto-detected from star file.')
     group.add_argument('--ind-ptcls', type=os.path.abspath, metavar='PKL', help='Filter starfile by particles (unique rlnGroupName values) using np array pkl as indices')
     group.add_argument('--ind-imgs', type=os.path.abspath, help='Filter starfile by particle images (star file rows) using np array pkl as indices')
     group.add_argument('--sort-ptcl-imgs', choices=('unsorted', 'dose_ascending', 'random'), default='unsorted', help='Sort the star file images on a per-particle basis by the specified criteria')
@@ -126,6 +134,7 @@ def train_batch(*,
                 batch_trans: torch.Tensor,
                 batch_ctf_params: torch.Tensor,
                 batch_recon_error_weights: torch.Tensor,
+                batch_dose_weights: torch.Tensor,
                 batch_hartley_2d_mask: torch.Tensor,
                 image_ctf_premultiplied: bool,
                 image_dose_weighted: bool,
@@ -148,6 +157,7 @@ def train_batch(*,
     :param batch_recon_error_weights: Batch of 2-D weights to be applied to the per-spatial-frequency error between the reconstructed slice and the input image.
             Calculated from critical dose exposure curves and electron beam vs sample tilt geometry.
             May be `torch.zeros((batchsize))` instead to indicate no weighting should be applied to the reconstructed slice error.
+    :param batch_dose_weights: Dose-only frequency weights per tilt image, shape (batchsize, ntilts, boxsize_ht**2).
     :param batch_hartley_2d_mask: Batch of 2-D masks to be applied per-spatial-frequency.
             Calculated as the intersection of critical dose exposure curves and a Nyquist-limited circular mask in reciprocal space, including masking the DC component.
     :param image_ctf_premultiplied: Whether images were multiplied by their CTF during particle extraction.
@@ -185,6 +195,7 @@ def train_batch(*,
                                                  batch_images_recon=batch_images_recon,
                                                  batch_ctf_weights=batch_ctf_weights,
                                                  batch_recon_error_weights=batch_recon_error_weights,
+                                                 batch_dose_weights=batch_dose_weights,
                                                  batch_hartley_2d_mask=batch_hartley_2d_mask,
                                                  image_ctf_premultiplied=image_ctf_premultiplied,
                                                  image_dose_weighted=image_dose_weighted,
@@ -297,6 +308,7 @@ def loss_function(*,
                   batch_images_recon: torch.Tensor,
                   batch_ctf_weights: torch.Tensor,
                   batch_recon_error_weights: torch.Tensor,
+                  batch_dose_weights: torch.Tensor,
                   batch_hartley_2d_mask: torch.Tensor,
                   image_ctf_premultiplied: bool,
                   image_dose_weighted: bool,
@@ -312,10 +324,12 @@ def loss_function(*,
     :param batch_ctf_weights: CTF evaluated at each spatial frequency corresponding to input images, shape (batchsize, ntilts, boxsize_ht**2) or None if no CTF should be applied
     :param batch_recon_error_weights: Batch of 2-D weights to be applied to the per-spatial-frequency error between each reconstructed slice and input image, shape (batchsize, ntilts, boxsize_ht**2).
             Calculated from critical dose exposure curves and electron beam vs sample tilt geometry.
+    :param batch_dose_weights: Dose-only frequency weights (without tilt weighting), shape (batchsize, ntilts, boxsize_ht**2).
+            Used to normalize dose weighting out of CTF-premultiplied input images before the loss comparison.
     :param batch_hartley_2d_mask: Batch of 2-D masks to be applied per-spatial-frequency.
             Calculated as the intersection of critical dose exposure curves and a Nyquist-limited circular mask in reciprocal space, including masking the DC component.
     :param image_ctf_premultiplied: Whether images were multiplied by their CTF during particle extraction.
-    :param image_dose_weighted: Whether images were multiplied by their exposure-dependent frequency weighting during particle extraction.    :param beta: scaling factor to apply to KLD during loss calculation.
+    :param image_dose_weighted: Whether images were multiplied by their exposure-dependent frequency weighting during particle extraction.
     :param beta: scaling factor to apply to KLD during loss calculation.
     :param beta_control: KL-Controlled VAE gamma. Beta is KL target.
     :return: total summed loss, generative loss between reconstructed slices and input images, and beta-weighted kld loss between latent embeddings and standard normal
@@ -331,6 +345,7 @@ def loss_function(*,
         # reconstruction error
         batch_images = batch_images[batch_hartley_2d_mask].view(-1)
         batch_recon_error_weights = batch_recon_error_weights[batch_hartley_2d_mask].view(-1)
+        batch_dose_weights = batch_dose_weights[batch_hartley_2d_mask].view(-1)
         if batch_ctf_weights is not None:
             batch_ctf_weights = batch_ctf_weights[batch_hartley_2d_mask].view(-1)
             batch_images_recon = batch_images_recon * batch_ctf_weights  # apply CTF to reconstructed image
@@ -341,8 +356,9 @@ def loss_function(*,
                 # reconstructed image needs to correspond to input ctf_premultiplied images, i.e. images that are doubly convolved with the CTF
                 batch_images_recon = batch_images_recon * batch_ctf_weights  # apply CTF to reconstructed image again
         if image_dose_weighted:
-            # images may have been extracted with dose weights pre-applied
-            batch_images_recon = batch_images_recon * batch_recon_error_weights
+            # divide dose weights out of input images so both sides compare on equal footing;
+            # clamp avoids division by zero at masked frequencies (l_dose_mask handles zero-weight regions)
+            batch_images = batch_images / batch_dose_weights.clamp(min=1e-6)
         gen_loss = torch.nanmean(batch_recon_error_weights * ((batch_images_recon - batch_images) ** 2))
 
         # latent loss
@@ -406,7 +422,7 @@ def encoder_inference(*,
                                                          persistent_workers=False,  # creating this dataloading for a single pass, no need for peristent workers
                                                          pin_memory=pin_memory)
 
-            for batch_images, _, batch_trans, batch_ctf_params, _, _, batch_indices in data_generator:
+            for batch_images, _, batch_trans, batch_ctf_params, _, _, batch_indices, _ in data_generator:
                 # transfer to GPU
                 batch_images = batch_images.to(lat.device)
                 batch_ctf_params = batch_ctf_params.to(lat.device)
@@ -517,7 +533,9 @@ def main(args):
 
     # load star file
     ptcls_star = load_sta_starfile(star_path=args.particles,
-                                   source_software=args.source_software)
+                                   source_software=args.source_software,
+                                   image_ctf_premultiplied=args.image_ctf_premultiplied,
+                                   image_dose_weighted=args.image_dose_weighted)
     ptcls_star.plot_particle_uid_ntilt_distribution(outpath=f'{args.outdir}/{os.path.basename(ptcls_star.sourcefile)}_particle_uid_ntilt_distribution.{args.plot_format}')
 
     # filter star file
@@ -747,7 +765,7 @@ def main(args):
         losses_accum = np.zeros(3)
         batch_it = 0
 
-        for batch_images, batch_rots, batch_trans, batch_ctf_params, batch_recon_error_weights, batch_hartley_2d_mask, batch_indices in data_train_generator:
+        for batch_images, batch_rots, batch_trans, batch_ctf_params, batch_recon_error_weights, batch_hartley_2d_mask, batch_indices, batch_dose_weights in data_train_generator:
             # impression counting
             batch_it += len(batch_indices)  # total number of ptcls seen
             global_it = nptcls * epoch + batch_it
@@ -759,6 +777,7 @@ def main(args):
             batch_trans = batch_trans.to(device)
             batch_ctf_params = batch_ctf_params.to(device)
             batch_recon_error_weights = batch_recon_error_weights.to(device)
+            batch_dose_weights = batch_dose_weights.to(device)
             batch_hartley_2d_mask = batch_hartley_2d_mask.to(device)
 
             # training minibatch
@@ -771,6 +790,7 @@ def main(args):
                                        batch_trans=batch_trans,
                                        batch_ctf_params=batch_ctf_params,
                                        batch_recon_error_weights=batch_recon_error_weights,
+                                       batch_dose_weights=batch_dose_weights,
                                        batch_hartley_2d_mask=batch_hartley_2d_mask,
                                        image_ctf_premultiplied=image_ctf_premultiplied,
                                        image_dose_weighted=image_dose_weighted,

--- a/tomodrgn/dataset.py
+++ b/tomodrgn/dataset.py
@@ -216,7 +216,7 @@ class TiltSeriesMRCData(data.Dataset):
         decoder_mask = np.asarray([self.spatial_frequency_dose_masks.get(cumulative_dose) for cumulative_dose in self.cumulative_doses[ptcl_img_ind]])
         decoder_weights = np.asarray(dose.combine_dose_tilt_weights(dose_weights, tilt_weights))
 
-        return images, rot, trans, ctf_params, decoder_weights, decoder_mask, idx_ptcl
+        return images, rot, trans, ctf_params, decoder_weights, decoder_mask, idx_ptcl, dose_weights
 
     def get(self, index):
         return self.ptcls[index]
@@ -623,7 +623,7 @@ class TomoParticlesMRCData(data.Dataset):
         decoder_mask = np.asarray([self.spatial_frequency_dose_masks.get(cumulative_dose) for cumulative_dose in self.cumulative_doses[ptcl_img_ind]])
         decoder_weights = np.asarray(dose.combine_dose_tilt_weights(dose_weights, tilt_weights))
 
-        return images, rot, trans, ctf_params, decoder_weights, decoder_mask, idx_ptcl
+        return images, rot, trans, ctf_params, decoder_weights, decoder_mask, idx_ptcl, dose_weights
 
     def get(self, index):
         return self.ptcls[index]

--- a/tomodrgn/starfile.py
+++ b/tomodrgn/starfile.py
@@ -1384,7 +1384,9 @@ class TomoParticlesStarfile(GenericStarfile):
 
     def __init__(self,
                  starfile: str,
-                 source_software: TOMOPARTICLESSTARFILE_STAR_SOURCES = 'auto'):
+                 source_software: TOMOPARTICLESSTARFILE_STAR_SOURCES = 'auto',
+                 image_ctf_premultiplied: bool | None = None,
+                 image_dose_weighted: bool | None = None):
         # the input star file is the optimisation set; store its path and contents for future writing
         assert is_starfile_optimisation_set(starfile)
         self.optimisation_set_star_path = os.path.abspath(starfile)
@@ -1452,6 +1454,8 @@ class TomoParticlesStarfile(GenericStarfile):
         self.sourcefile_filtered = None
 
         self.source_software = source_software
+        self._override_image_ctf_premultiplied = image_ctf_premultiplied
+        self._override_image_dose_weighted = image_dose_weighted
 
         # infer the upstream metadata format
         if source_software == 'auto':
@@ -1464,6 +1468,13 @@ class TomoParticlesStarfile(GenericStarfile):
             self._relion_metadata_mapping()
         else:
             raise ValueError(f'Unrecognized source_software {source_software} not one of known starfile sources for TomoParticlesStarfile {TOMOPARTICLESSTARFILE_STAR_SOURCES}')
+
+        if self._override_image_ctf_premultiplied is not None:
+            utils.log(f'Overriding image_ctf_premultiplied: {self.image_ctf_premultiplied} -> {self._override_image_ctf_premultiplied}')
+            self.image_ctf_premultiplied = self._override_image_ctf_premultiplied
+        if self._override_image_dose_weighted is not None:
+            utils.log(f'Overriding image_dose_weighted: {self.image_dose_weighted} -> {self._override_image_dose_weighted}')
+            self.image_dose_weighted = self._override_image_dose_weighted
 
     def _warptools_metadata_mapping(self):
         # in the examples I have seen so far, the warptools metadata and relion metadata are equivalent for the fields required by tomodrgn
@@ -1551,7 +1562,7 @@ class TomoParticlesStarfile(GenericStarfile):
 
         # image processing applied during particle extraction
         self.image_ctf_premultiplied = bool(self.blocks[self.block_optics]['_rlnCtfDataAreCtfPremultiplied'].to_numpy()[0])
-        self.image_dose_weighted = True  # warptools applie fixed exposure weights per-frequency for each extracted image
+        self.image_dose_weighted = True  # warptools applies fixed exposure weights per-frequency for each extracted image
         self.image_tilt_weighted = False
 
         # note columns added during init, so that we can remove these columns later when writing the star file
@@ -2092,7 +2103,9 @@ def is_starfile_optimisation_set(star_path: str) -> bool:
 
 
 def load_sta_starfile(star_path: str,
-                      source_software: KNOWN_STAR_SOURCES = 'auto') -> TiltSeriesStarfile | TomoParticlesStarfile:
+                      source_software: KNOWN_STAR_SOURCES = 'auto',
+                      image_ctf_premultiplied: bool | None = None,
+                      image_dose_weighted: bool | None = None) -> TiltSeriesStarfile | TomoParticlesStarfile:
     """
     Loads a tomodrgn star file handling class (either ``TiltSeriesStarfile`` or ``TomoParticlesStarfile``) from a star file on disk.
     The input ``star_path`` must point to either a particle imageseries star file (e.g. from Warp v1) or an optimisation set star file (e.g. from RELION v5).
@@ -2101,18 +2114,29 @@ def load_sta_starfile(star_path: str,
     :param star_path: path to star file to load on disk
     :param source_software: type of source software used to create the star file, used to indicate the appropriate star file handling class to instantiate.
             Default of 'auto' tries to infer the appropriate star file handling class based on whether ``star_path`` is an optimisation set star file.
+    :param image_ctf_premultiplied: optional override for whether CTF premultiplication was applied during particle extraction.
+            Only applied when loading a ``TomoParticlesStarfile``. If None (default), the value is read from the star file.
+            If True or False, this overrides the value inferred from the star file.
+    :param image_dose_weighted: optional override for whether dose weighting was applied during particle extraction.
+            Only applied when loading a ``TomoParticlesStarfile``. If None (default), the standard default for the detected software is used.
+            If True or False, this overrides that default.
     :return: The created starfile object (either ``TiltSeriesStarfile`` or ``TomoParticlesStarfile``)
     """
 
     if source_software == 'auto':
         if is_starfile_optimisation_set(star_path):
-            return TomoParticlesStarfile(star_path)
+            return TomoParticlesStarfile(star_path,
+                                         image_ctf_premultiplied=image_ctf_premultiplied,
+                                         image_dose_weighted=image_dose_weighted)
         else:
             return TiltSeriesStarfile(star_path)
     else:
         if source_software in get_args(TILTSERIESSTARFILE_STAR_SOURCES):
             return TiltSeriesStarfile(star_path, source_software=source_software)
         elif source_software in get_args(TOMOPARTICLESSTARFILE_STAR_SOURCES):
-            return TomoParticlesStarfile(star_path, source_software=source_software)
+            return TomoParticlesStarfile(star_path,
+                                         source_software=source_software,
+                                         image_ctf_premultiplied=image_ctf_premultiplied,
+                                         image_dose_weighted=image_dose_weighted)
         else:
             raise ValueError(f'Unrecognized source_software {source_software} not one of known starfile sources {KNOWN_STAR_SOURCES}')


### PR DESCRIPTION
Now users can use uncorrected/non-multiplied particle stacks as original Warp v1 outputs